### PR TITLE
fix: wagtail 7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ wagtail's snippets.
 
 This app is tested to runs with:
 
-* Django 4.2, 5.0
-* Wagtail 5.0, 5.1, 5.2, 6.0, 6.1, 6.2
+* Django 4.2, 5.0, 5.2
+* Wagtail 5.0, 5.1, 5.2, 6.0, 6.1, 6.2, 7.0
 * Parler 2.3 (probably older ones to, it's just not tested)
 * Python 3.9, 3.11
 
@@ -65,11 +65,14 @@ Then, in settings.py, add `wagtail_parler` to the installed apps.
 # settings.py
 
 INSTALLED_APPS = [
+    # "wagtail.users" # for wagtail >= 7
     # …
     "wagtail_parler",
     # …
 ]
 ```
+
+ATTENTION! Since wagtail 7, you need also to add `wagtail.users` in the installed app if not already done!
 
 ## Basic Usage
 

--- a/wagtail_parler/handlers.py
+++ b/wagtail_parler/handlers.py
@@ -22,6 +22,7 @@ from django.forms.models import fields_for_model
 from django.utils.translation import gettext_lazy as _
 
 # Third Party
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.panels import FieldPanel
 from wagtail.admin.panels import ObjectList
 from wagtail.admin.panels import TabbedInterface
@@ -187,6 +188,9 @@ class ParlerAdminWagtailMixin:
             main_form_meta_attrs["formfield_callback"] = self.formfield_for_dbfield
         form_options = base_handlers.bind_to_model(self.model).get_form_options()
         form_options["fields"] = displayed_fields
+        if WAGTAIL_VERSION[0] >= 7:
+            # wagtail 7 add "defered_required_on_fields"
+            form_options.pop("defered_required_on_fields")
         base_form_class = build_translations_form(
             self.model,
             fields_for_model_kwargs=form_options,

--- a/wagtail_parler/handlers.py
+++ b/wagtail_parler/handlers.py
@@ -190,7 +190,7 @@ class ParlerAdminWagtailMixin:
         form_options["fields"] = displayed_fields
         if WAGTAIL_VERSION[0] >= 7:
             # wagtail 7 add "defer_required_on_fields"
-            form_options.pop("defer_required_on_fields")
+            form_options.pop("defer_required_on_fields", None)
         base_form_class = build_translations_form(
             self.model,
             fields_for_model_kwargs=form_options,

--- a/wagtail_parler/handlers.py
+++ b/wagtail_parler/handlers.py
@@ -189,8 +189,8 @@ class ParlerAdminWagtailMixin:
         form_options = base_handlers.bind_to_model(self.model).get_form_options()
         form_options["fields"] = displayed_fields
         if WAGTAIL_VERSION[0] >= 7:
-            # wagtail 7 add "defered_required_on_fields"
-            form_options.pop("defered_required_on_fields")
+            # wagtail 7 add "defer_required_on_fields"
+            form_options.pop("defer_required_on_fields")
         base_form_class = build_translations_form(
             self.model,
             fields_for_model_kwargs=form_options,

--- a/wagtail_parler_tests/settings.py
+++ b/wagtail_parler_tests/settings.py
@@ -10,9 +10,11 @@ BASE_PATH = os.path.join(os.path.dirname(__file__), "..")
 USE_TZ = True
 TIME_ZONE = "Europe/Paris"
 
+# In some version of wagtail (>7), "wagtail.users" is added only if some settings are set.
+if "wagtail.users" not in INSTALLED_APPS:
+    INSTALLED_APPS += ["wagtail.users"]
 # add our apps and remove wagtail test apps
 INSTALLED_APPS = [
-    "wagtail.users",
     "wagtail_parler",
     "wagtail_parler_tests",
     "parler",

--- a/wagtail_parler_tests/settings.py
+++ b/wagtail_parler_tests/settings.py
@@ -12,6 +12,7 @@ TIME_ZONE = "Europe/Paris"
 
 # add our apps and remove wagtail test apps
 INSTALLED_APPS = [
+    "wagtail.users",
     "wagtail_parler",
     "wagtail_parler_tests",
     "parler",


### PR DESCRIPTION
wagtail added a `defered_required_on_fields` on model form, that should not be pass to `fields_for_model_kwargs`