### PR TITLE
test: update tox environment matrix for django 5 and wagtail 7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py39-django42-wagtail{50,51}
-    py311-django42-wagtail{51,52,60,61,62}
-    py{39,311}-django42-wagtailmain
+    py311-django{42,52}-wagtail{51,52,60,61,62,70}
+    py{39,311}-django{42,52}-wagtail{70,main}
     py312-djangomain-wagtailmain
     qa
 
@@ -18,6 +18,7 @@ basepython =
 
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
     wagtail41: wagtail>=4.1,<4.2
     wagtail42: wagtail>=4.2,<4.3
@@ -27,9 +28,10 @@ deps =
     wagtail60: wagtail>=6.0,<6.1
     wagtail61: wagtail>=6.1,<6.2
     wagtail62: wagtail>=6.2,<6.3
+    wagtail70: wagtail>=7.0,<7.1
     wagtailmain: https://github.com/wagtail/wagtail/archive/main.tar.gz
     wagtail{50,51,52}: wagtail-modeladmin>=1.0,<2.0
-    wagtail{60,61,62,main}: wagtail-modeladmin>=2.0,<3.0
+    wagtail{60,61,62,70,main}: wagtail-modeladmin>=2.0,<3.0
     qa: black
     qa: flake8
     qa: mypy


### PR DESCRIPTION
Add django 5.2 and wagtail 7.0 to the tox matrix env test.

The test should fail right now for django main and wagtail main.

See pr #7  for the compatibility